### PR TITLE
Chunk Loader balancing

### DIFF
--- a/config/immibis.cfg
+++ b/config/immibis.cfg
@@ -15,15 +15,15 @@ general {
     B:chunkloader.enableCrafting=false
 
     # comma-separated list of mod:item-name@meta=number-of-ticks or mod:item-name=number-of-ticks
-    S:chunkloader.fuels=minecraft:coal@1=1200,minecraft:nether_brick=200,minecraft:netherrack=80,minecraft:coal@0=12000,minecraft:ender_eye=36000,minecraft:stone=60,minecraft:ender_pearl=18000,minecraft:cobblestone=20,minecraft:magma_cream=18000,minecraft:redstone=1200,minecraft:glowstone_dust=2400,minecraft:dirt=20
+    S:chunkloader.fuels=TConstruct:MetalBlock@10=360000
     B:chunkloader.hideOtherPlayersLoadersInF9=false
 
     # Maximum number of chunks loaded by each player. Use -2 for unlimited.
-    I:chunkloader.maxChunksPerPlayer=-2
+    I:chunkloader.maxChunksPerPlayer=9
 
     # If true, chunkloaders placed by a player will only load chunks while that player is online.
     B:chunkloader.requireOnline=true
-    B:chunkloader.useFuel=false
+    B:chunkloader.useFuel=true
 
     # name of TPS command, without the slash. leave blank to disable.
     S:core.command.tps.name=tps


### PR DESCRIPTION
Vorschlag für Dimensional Anchors:
- Fuel für den Chunk Loader aktiviert als Fuel Solid Ender = 5Std Laufzeit pro Chunk.
- Limitierung auf 9 Chunks pro Spieler ggf. aufs doppelte anheben, ist im Vergleich zu den MFR Teilen wohl etwas wenig.